### PR TITLE
libreoffice-fresh: Fix broken shortcuts #5059

### DIFF
--- a/bucket/libreoffice-fresh.json
+++ b/bucket/libreoffice-fresh.json
@@ -18,27 +18,27 @@
     },
     "shortcuts": [
         [
-            "program\\sbase.exe",
+            "LibreOffice\\program\\sbase.exe",
             "LibreOffice\\LibreOffice Base"
         ],
         [
-            "program\\scalc.exe",
+            "LibreOffice\\program\\scalc.exe",
             "LibreOffice\\LibreOffice Calc"
         ],
         [
-            "program\\sdraw.exe",
+            "LibreOffice\\program\\sdraw.exe",
             "LibreOffice\\LibreOffice Draw"
         ],
         [
-            "program\\simpress.exe",
+            "LibreOffice\\program\\simpress.exe",
             "LibreOffice\\LibreOffice Impress"
         ],
         [
-            "program\\smath.exe",
+            "LibreOffice\\program\\smath.exe",
             "LibreOffice\\LibreOffice Math"
         ],
         [
-            "program\\swriter.exe",
+            "LibreOffice\\program\\swriter.exe",
             "LibreOffice\\LibreOffice Writer"
         ]
     ],


### PR DESCRIPTION
`libreoffice-fresh` installs the executables to `apps\libreoffice-fresh\LibreOffice\program`, while the manifest currently references `apps\libreoffice-fresh\program`.